### PR TITLE
Upgrade webpack to v3

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["latest", "stage-0", "react"]
+  "presets": ["env", "stage-0", "react"]
 }

--- a/package.json
+++ b/package.json
@@ -44,17 +44,17 @@
     "autoprefixer-loader": "^3.2.0",
     "babel": "^6.5.2",
     "babel-cli": "^6.16.0",
-    "babel-loader": "^6.2.5",
-    "babel-preset-latest": "^6.16.0",
+    "babel-loader": "^7.1.2",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
     "css-loader": "^0.25.0",
     "json-loader": "^0.5.4",
-    "node-sass": "^3.10.1",
+    "node-sass": "^4.7.2",
     "optimize-css-assets-webpack-plugin": "^1.3.0",
-    "sass-loader": "^4.0.2",
+    "sass-loader": "^6.0.6",
     "style-loader": "^0.13.1",
-    "webpack": "^1.13.2",
-    "webpack-dev-server": "^1.16.2"
+    "webpack": "^3.10.0",
+    "webpack-dev-server": "^2.9.5"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,10 @@
 var OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin')
+const path = require('path');
 
 module.exports = {
     entry: "./src/index.js",
     output: {
-        path: "dist/assets",
+        path: path.resolve(__dirname, "dist/assets"),
         filename: "bundle.js",
         publicPath: "assets"
     },
@@ -17,10 +18,12 @@ module.exports = {
             {
                 test: /\.js$/,
                 exclude: /(node_modules)/,
-                loader: ['babel'],
-                query: {
-                    presets: ['latest', 'stage-0', 'react']
-                }
+                use: {
+                  loader: 'babel-loader',
+                  options: {
+                      presets: ['env', 'stage-0', 'react']
+                  }
+                },
             },
             {
                 test: /\.json$/,


### PR DESCRIPTION
Also upgrades:
* webpack-dev-server to v2
* sass-loader to v6
* babel-loader to v7
* node-sass to v4

Uses babel-preset-env to eliminate deprecation warning.

Note: the `babel` package is deprecated. I suggest we use `babel-core` instead to be up to date. Let me know!